### PR TITLE
Add CORS support

### DIFF
--- a/Front_End/app.py
+++ b/Front_End/app.py
@@ -2,9 +2,11 @@
 import os
 
 from flask import Flask, render_template
-
+from flask_cors import CORS
 
 app = Flask(__name__)
+CORS(app)
+
 
 # Get env variables
 MAPBOX_TOKEN = os.environ.get('MAPBOX_TOKEN')

--- a/Front_End/requirements.txt
+++ b/Front_End/requirements.txt
@@ -1,1 +1,2 @@
 flask
+flask-cors==3.0.7

--- a/Twitter_Consumer/app.py
+++ b/Twitter_Consumer/app.py
@@ -4,10 +4,13 @@ import json
 import time
 
 from flask import Flask, Response
+from flask_cors import CORS
 from kafka import KafkaConsumer
 
 
 app = Flask(__name__)
+CORS(app)
+
 
 # Get env variables
 KAFKA_BROKER_URL = os.environ.get('KAFKA_BROKER_URL')

--- a/Twitter_Consumer/requirements.txt
+++ b/Twitter_Consumer/requirements.txt
@@ -1,4 +1,5 @@
 kafka-python
 tweepy
 flask
+flask-cors==3.0.7
 gunicorn


### PR DESCRIPTION
I see some errors while inspecting Google Chrome's console: the frontend app cannot subscribe to the general & coord streams running in the Twitter Consumer container due to CORS errors. You can bypass this issue by permitting the frontend app's domain to access the corresponding services. A fast -but insecure- way to address this is to use Flask-Cors library to enable any incoming domain to access. A better approach is given below:

```python
app = Flask(__name__)
cors = CORS(app, resources={
    r"/topic/*": {
        "origins": "https://coronavirus.twitter-realtime.com" # origins is * by default
    }
})
```